### PR TITLE
replcae cdiff with colordiff in automated test

### DIFF
--- a/src/Tools/runtests_shell/runtests.sh
+++ b/src/Tools/runtests_shell/runtests.sh
@@ -24,11 +24,6 @@ COLOR_RED="\033[1;31m"
 COLOR_RESET="\033[0m"
 HR="----------------------------------------------------------------------------------------------------------------------------------------------------------------"
 
-# A dirty hack to force cdiff to print the result in a non-interactive mode
-sudo cp /bin/less $TOOL_DIR/less_bck
-sudo rm /bin/less
-sudo ln $TOOL_DIR/cdiff_less_replacement.sh /bin/less
-
 # Compile and run every PHP file in ./tests and check the output against the one from the PHP interpreter
 for PHP_FILE in $(find ./tests -name *.php)
 do
@@ -51,17 +46,12 @@ do
       echo "$PHP_OUTPUT" > $PHP_TMP_FILE
       echo "$PEACH_OUTPUT" > $PEACH_TMP_FILE
       # TODO: Hide the whole comparison header (tail after the cdiff won't work)
-      git diff --no-index -- $PHP_TMP_FILE $PEACH_TMP_FILE | tail -n +3 | cdiff -s
+      git diff --no-index -- $PHP_TMP_FILE $PEACH_TMP_FILE | tail -n +3 | colordiff -s
       echo $HR
       FAILURE="FAILURE"
     fi
   fi
 done
-
-# Revert the hack of command less
-sudo rm /bin/less
-sudo cp $TOOL_DIR/less_bck /bin/less
-sudo rm $TOOL_DIR/less_bck
 
 # Fail if any of the tests failed
 if [ $FAILURE ] ; then


### PR DESCRIPTION
`cdiff` is meant for interactive use, as you discovered. You have worked-around this by replacing the `less` binary on the system with a wrapper around `tail`. This PR removes that dirty hack in favour of using `colordiff` rather than the interactive wrapper `cdiff`.