### PR TITLE
Removed fixed Options.OptimizationLevels.

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundStatement.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundStatement.cs
@@ -209,7 +209,7 @@ namespace Pchp.CodeAnalysis.Semantics
 
                 holder.EmitInit(module, (il) =>
                 {
-                    var cg = new CodeGenerator(il, module, diagnostic, OptimizationLevel.Release, false,
+                    var cg = new CodeGenerator(il, module, diagnostic, compilation.Options.OptimizationLevel, false,
                         holder.ContainingType, new ArgPlace(compilation.CoreTypes.Context, 1), new ArgPlace(holder, 0));
 
                     var valuePlace = new FieldPlace(cg.ThisPlaceOpt, holder.ValueField);
@@ -237,7 +237,7 @@ namespace Pchp.CodeAnalysis.Semantics
                 {
                     // emit default value only if it won't be initialized by Init above
 
-                    var cg = new CodeGenerator(il, module, diagnostic, OptimizationLevel.Release, false,
+                    var cg = new CodeGenerator(il, module, diagnostic, compilation.Options.OptimizationLevel, false,
                         holder.ContainingType, null, new ArgPlace(holder, 0));
 
                     var valuePlace = new FieldPlace(cg.ThisPlaceOpt, holder.ValueField);

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceRoutineSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceRoutineSymbol.cs
@@ -114,7 +114,7 @@ namespace Pchp.CodeAnalysis.Symbols
             var body = MethodGenerator.GenerateMethodBody(module, ghost,
                 (il) =>
                 {
-                    var cg = new CodeGenerator(il, module, diagnostic, OptimizationLevel.Release, false, this.ContainingType, this.GetContextPlace(), this.GetThisPlace());
+                    var cg = new CodeGenerator(il, module, diagnostic, module.Compilation.Options.OptimizationLevel, false, this.ContainingType, this.GetContextPlace(), this.GetThisPlace());
 
                     // return (T){routine}(p0, ..., pN);
                     cg.EmitConvert(cg.EmitThisCall(this, ghost), 0, ghost.ReturnType);
@@ -232,7 +232,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
             module.SetMethodBody(this, MethodGenerator.GenerateMethodBody(module, this, (il) =>
             {
-                var cg = new CodeGenerator(this, il, module, diagnostic, OptimizationLevel.Release, false);
+                var cg = new CodeGenerator(this, il, module, diagnostic, module.Compilation.Options.OptimizationLevel, false);
 
                 // Template: return default(T)
                 cg.EmitRetDefault();

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceTypeSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SourceTypeSymbol.cs
@@ -68,7 +68,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 // note, their initializers do not have Context available, since they are not bound to a Context
 
                 var cctor = module.GetStaticCtorBuilder(this);
-                var cg = new CodeGenerator(cctor, module, DiagnosticBag.GetInstance(), OptimizationLevel.Release, false, this, null, null);
+                var cg = new CodeGenerator(cctor, module, DiagnosticBag.GetInstance(), module.Compilation.Options.OptimizationLevel, false, this, null, null);
 
                 foreach (var f in sflds)
                 {
@@ -98,7 +98,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
             module.SetMethodBody(invoke, MethodGenerator.GenerateMethodBody(module, invoke, il =>
             {
-                var cg = new CodeGenerator(il, module, diagnostics, OptimizationLevel.Release, false, this, new ParamPlace(invoke.Parameters[0]), new ArgPlace(this, 0));
+                var cg = new CodeGenerator(il, module, diagnostics, module.Compilation.Options.OptimizationLevel, false, this, new ParamPlace(invoke.Parameters[0]), new ArgPlace(this, 0));
 
                 var argsplace = new ParamPlace(invoke.Parameters[1]);
                 var args_element = ((ArrayTypeSymbol)argsplace.TypeOpt).ElementType;
@@ -176,7 +176,7 @@ namespace Pchp.CodeAnalysis.Symbols
             module.SetMethodBody(tophpvalue, MethodGenerator.GenerateMethodBody(module, tophpvalue, il =>
             {
                 var thisPlace = new ArgPlace(this, 0);
-                var cg = new CodeGenerator(il, module, diagnostics, OptimizationLevel.Release, false, this, new FieldPlace(thisPlace, this.ContextStore), thisPlace);
+                var cg = new CodeGenerator(il, module, diagnostics, module.Compilation.Options.OptimizationLevel, false, this, new FieldPlace(thisPlace, this.ContextStore), thisPlace);
 
                 // return PhpValue.FromClass(this)
                 cg.EmitThis();
@@ -195,7 +195,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 {
                     Debug.Assert(SpecialParameterSymbol.IsContextParameter(ctor.Parameters[0]));
 
-                    var cg = new CodeGenerator(il, module, diagnostics, OptimizationLevel.Release, false, this, new ParamPlace(ctor.Parameters[0]), new ArgPlace(this, 0));
+                    var cg = new CodeGenerator(il, module, diagnostics, module.Compilation.Options.OptimizationLevel, false, this, new ParamPlace(ctor.Parameters[0]), new ArgPlace(this, 0));
 
                     Debug.Assert(ctor.BaseCtor != null);
 
@@ -261,7 +261,7 @@ namespace Pchp.CodeAnalysis.Symbols
                 module.SetMethodBody(tostring, MethodGenerator.GenerateMethodBody(module, tostring, il =>
                 {
                     var thisPlace = new ArgPlace(this, 0);
-                    var cg = new CodeGenerator(il, module, DiagnosticBag.GetInstance(), OptimizationLevel.Release, false, this, new FieldPlace(thisPlace, this.ContextStore), thisPlace);
+                    var cg = new CodeGenerator(il, module, DiagnosticBag.GetInstance(), module.Compilation.Options.OptimizationLevel, false, this, new FieldPlace(thisPlace, this.ContextStore), thisPlace);
 
                     if (__tostring != null)
                     {

--- a/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SynthesizedStaticFieldsHolder.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Symbols/SynthesizedStaticFieldsHolder.cs
@@ -24,7 +24,7 @@ namespace Pchp.CodeAnalysis.Symbols
                         
             var body = MethodGenerator.GenerateMethodBody(module, ctor, (il) =>
             {
-                var cg = new CodeGenerator(il, module, diagnostic, OptimizationLevel.Release, false, this, null, new ArgPlace(this, 0));
+                var cg = new CodeGenerator(il, module, diagnostic, module.Compilation.Options.OptimizationLevel, false, this, null, new ArgPlace(this, 0));
 
                 // base..ctor()
                 cg.EmitThis();   // this
@@ -71,7 +71,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
             var body = MethodGenerator.GenerateMethodBody(module, initMethod, (il) =>
             {
-                var cg = new CodeGenerator(il, module, diagnostic, OptimizationLevel.Release, false, this, new ArgPlace(tt.Context, 1), new ArgPlace(this, 0));
+                var cg = new CodeGenerator(il, module, diagnostic, module.Compilation.Options.OptimizationLevel, false, this, new ArgPlace(tt.Context, 1), new ArgPlace(this, 0));
 
                 foreach (var fld in this.Fields)
                 {


### PR DESCRIPTION
Sometimes both `DeclaringCompilation.Options.OptimizationLevel` and `module.Compilation.Options.OptimizationLevel` could be used. Not sure I picket the right one.