### PR TITLE
Error codes cleanup.

### DIFF
--- a/src/Peachpie.CodeAnalysis/Errors/ErrorCode.cs
+++ b/src/Peachpie.CodeAnalysis/Errors/ErrorCode.cs
@@ -67,8 +67,6 @@ namespace Pchp.CodeAnalysis.Errors
         ERR_ResourceNotUnique,
         ERR_TooManyUserStrings,
         ERR_NotYetImplemented, // Used for all valid PHP constructs that Peachipe doesn't currently support.
-        ERR_YieldAsExpression, // TODO: Remove after starting to support yields as expressions
-        ERR_YieldInTryCatch,   // TODO: Remove after starting to support yields in exception control blocks
         ERR_CircularBase,
         ERR_TypeNameCannotBeResolved,
 


### PR DESCRIPTION
- deleted unused error codes
- AFAIK no diagnostic reports `ERR_CircularBase` or `ERR_TypeNameCannotBeResolved` so it shouldn't be breaking anything.