### PR TITLE
declaring static, global variables

### DIFF
--- a/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
@@ -230,10 +230,10 @@ namespace Pchp.CodeAnalysis.CodeGen
             //var holders = _cg.Module.SynthesizedManager.GetMembers<SynthesizedStaticLocHolder>(_container);
             //var holder = holders.FirstOrDefault(h => ReferenceEquals(h.DeclaringMethod, _cg.Routine) && h.VariableName == locName && h.ValueType == locType);
             //if (holder == null)
-            {
+            //{
                 var holder = new SynthesizedStaticLocHolder(_cg.Routine, locName, locType);
                 _cg.Module.SynthesizedManager.AddNestedType(_container, holder);
-            }
+            //}
 
             return holder;
         }

--- a/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
@@ -226,11 +226,14 @@ namespace Pchp.CodeAnalysis.CodeGen
 
         internal SynthesizedStaticLocHolder DeclareStaticLocalHolder(string locName, TypeSymbol locType)
         {
-            // TODO: make only one for locName in routine
-
-            var holder = new SynthesizedStaticLocHolder(_cg.Routine, locName, locType);
-
-            _cg.Module.SynthesizedManager.AddNestedType(_container, holder);
+            //// TODO: check the holder for static 'locName' isn't defined already
+            //var holders = _cg.Module.SynthesizedManager.GetMembers<SynthesizedStaticLocHolder>(_container);
+            //var holder = holders.FirstOrDefault(h => ReferenceEquals(h.DeclaringMethod, _cg.Routine) && h.VariableName == locName && h.ValueType == locType);
+            //if (holder == null)
+            {
+                var holder = new SynthesizedStaticLocHolder(_cg.Routine, locName, locType);
+                _cg.Module.SynthesizedManager.AddNestedType(_container, holder);
+            }
 
             return holder;
         }

--- a/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/DynamicOperationFactory.cs
@@ -226,6 +226,8 @@ namespace Pchp.CodeAnalysis.CodeGen
 
         internal SynthesizedStaticLocHolder DeclareStaticLocalHolder(string locName, TypeSymbol locType)
         {
+            // TODO: make only one for locName in routine
+
             var holder = new SynthesizedStaticLocHolder(_cg.Routine, locName, locType);
 
             _cg.Module.SynthesizedManager.AddNestedType(_container, holder);

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundBlock.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundBlock.cs
@@ -14,7 +14,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
 {
     partial class BoundBlock : IGenerator
     {
-        internal virtual void Emit(CodeGenerator cg)
+        internal override void Emit(CodeGenerator cg)
         {
             // emit contained statements
             if (_statements.Count != 0)

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundVariable.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundVariable.cs
@@ -97,43 +97,6 @@ namespace Pchp.CodeAnalysis.Semantics
         internal override IPlace Place(ILBuilder il) => null;
     }
 
-    //partial class BoundStaticLocal
-    //{
-    //    /// <summary>
-    //    /// Place of the local variable containing the holder instance.
-    //    /// </summary>
-    //    internal IPlace _holderPlace;
-
-    //    internal SynthesizedStaticLocHolder _holder;
-
-    //    internal override void EmitInit(CodeGenerator cg)
-    //    {
-    //        // variable holder class
-    //        _holder = cg.Factory.DeclareStaticLocalHolder(this.Name, (TypeSymbol)this.Variable.Type);
-
-    //        // local with its instance
-    //        var symbol = new SynthesizedLocalSymbol(cg.Routine, this.Name, _holder);
-    //        var loc = cg.Builder.LocalSlotManager.DeclareLocal(_holder, symbol, symbol.Name, SynthesizedLocalKind.OptimizerTemp, LocalDebugId.None, 0, LocalSlotConstraints.None, false, default(ImmutableArray<TypedConstant>), false);
-
-    //        _holderPlace = new LocalPlace(loc);
-
-    //        // place = holder.value
-    //        _place = new FieldPlace(_holderPlace, _holder.ValueField);
-
-    //        if (cg.HasUnoptimizedLocals)
-    //        {
-    //            // TODO reference to <locals>
-    //        }
-    //    }
-
-    //    internal override IBoundReference BindPlace(ILBuilder il, BoundAccess access, TypeRefMask thint)
-    //    {
-    //        return new BoundLocalPlace(_place, access, thint);
-    //    }
-
-    //    internal override IPlace Place(ILBuilder il) => _place;
-    //}
-
     partial class BoundParameter
     {
         /// <summary>

--- a/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundVariable.cs
+++ b/src/Peachpie.CodeAnalysis/CodeGen/Graph/BoundVariable.cs
@@ -97,42 +97,42 @@ namespace Pchp.CodeAnalysis.Semantics
         internal override IPlace Place(ILBuilder il) => null;
     }
 
-    partial class BoundStaticLocal
-    {
-        /// <summary>
-        /// Place of the local variable containing the holder instance.
-        /// </summary>
-        internal IPlace _holderPlace;
+    //partial class BoundStaticLocal
+    //{
+    //    /// <summary>
+    //    /// Place of the local variable containing the holder instance.
+    //    /// </summary>
+    //    internal IPlace _holderPlace;
 
-        internal SynthesizedStaticLocHolder _holder;
+    //    internal SynthesizedStaticLocHolder _holder;
 
-        internal override void EmitInit(CodeGenerator cg)
-        {
-            // variable holder class
-            _holder = cg.Factory.DeclareStaticLocalHolder(this.Name, (TypeSymbol)this.Variable.Type);
+    //    internal override void EmitInit(CodeGenerator cg)
+    //    {
+    //        // variable holder class
+    //        _holder = cg.Factory.DeclareStaticLocalHolder(this.Name, (TypeSymbol)this.Variable.Type);
 
-            // local with its instance
-            var symbol = new SynthesizedLocalSymbol(cg.Routine, this.Name, _holder);
-            var loc = cg.Builder.LocalSlotManager.DeclareLocal(_holder, symbol, symbol.Name, SynthesizedLocalKind.OptimizerTemp, LocalDebugId.None, 0, LocalSlotConstraints.None, false, default(ImmutableArray<TypedConstant>), false);
+    //        // local with its instance
+    //        var symbol = new SynthesizedLocalSymbol(cg.Routine, this.Name, _holder);
+    //        var loc = cg.Builder.LocalSlotManager.DeclareLocal(_holder, symbol, symbol.Name, SynthesizedLocalKind.OptimizerTemp, LocalDebugId.None, 0, LocalSlotConstraints.None, false, default(ImmutableArray<TypedConstant>), false);
 
-            _holderPlace = new LocalPlace(loc);
+    //        _holderPlace = new LocalPlace(loc);
 
-            // place = holder.value
-            _place = new FieldPlace(_holderPlace, _holder.ValueField);
+    //        // place = holder.value
+    //        _place = new FieldPlace(_holderPlace, _holder.ValueField);
 
-            if (cg.HasUnoptimizedLocals)
-            {
-                // TODO reference to <locals>
-            }
-        }
+    //        if (cg.HasUnoptimizedLocals)
+    //        {
+    //            // TODO reference to <locals>
+    //        }
+    //    }
 
-        internal override IBoundReference BindPlace(ILBuilder il, BoundAccess access, TypeRefMask thint)
-        {
-            return new BoundLocalPlace(_place, access, thint);
-        }
+    //    internal override IBoundReference BindPlace(ILBuilder il, BoundAccess access, TypeRefMask thint)
+    //    {
+    //        return new BoundLocalPlace(_place, access, thint);
+    //    }
 
-        internal override IPlace Place(ILBuilder il) => _place;
-    }
+    //    internal override IPlace Place(ILBuilder il) => _place;
+    //}
 
     partial class BoundParameter
     {
@@ -321,29 +321,18 @@ namespace Pchp.CodeAnalysis.Semantics
         }
     }
 
-    partial class BoundGlobalVariable
+    partial class BoundSuperGlobalVariable
     {
         internal override void EmitInit(CodeGenerator cg)
         {
-            if (!_name.IsAutoGlobal)
-            {
-                // TODO: create shadow local in case we can
-            }
+            Debug.Assert(_name.IsAutoGlobal);
         }
 
         internal override IBoundReference BindPlace(ILBuilder il, BoundAccess access, TypeRefMask thint)
         {
-            // IBoundReference of $_GLOBALS[<name>]
+            Debug.Assert(_name.IsAutoGlobal);
 
-            if (_name.IsAutoGlobal)
-            {
-                return new BoundSuperglobalPlace(_name, access);
-            }
-            else
-            {
-                // <variables>[<name>]
-                return new BoundGlobalPlace(new BoundLiteral(_name.Value), access);
-            }
+            return new BoundSuperglobalPlace(_name, access);
         }
 
         internal override IPlace Place(ILBuilder il)

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/DiagnosingVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/DiagnosingVisitor.cs
@@ -191,11 +191,6 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
 
         public override void VisitStaticStatement(BoundStaticVariableStatement x)
         {
-            // TODO: Remove once fix for static variables handling in methods with unoptimized locals is done.
-            if (_routine.IsGeneratorMethod())
-            {
-                _diagnostics.Add(_routine, x.PhpSyntax, ErrorCode.ERR_NotYetImplemented, "Having static variables in generator methods");
-            }
             base.VisitStaticStatement(x);
         }
 

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/ExpressionAnalysis.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/ExpressionAnalysis.cs
@@ -343,7 +343,7 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
                 {
                     var vartype = previoustype;
 
-                    if (vartype.IsVoid || x.Variable.VariableKind == VariableKind.GlobalVariable)
+                    if (vartype.IsVoid || Routine.IsGlobalScope)
                     {
                         // in global code or in case of undefined variable,
                         // assume the type is mixed (unspecified).

--- a/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
+++ b/src/Peachpie.CodeAnalysis/FlowAnalysis/FlowState.cs
@@ -360,28 +360,6 @@ namespace Pchp.CodeAnalysis.FlowAnalysis
             //_varKindMap[varname] = kind;
         }
 
-        /// <summary>
-        /// Gets kind of variable declaration in this state.
-        /// </summary>
-        public VariableKind GetVarKind(VariableHandle handle)
-        {
-            handle.ThrowIfInvalid();
-
-            //// explicit variable declaration
-            //if (_varKindMap != null)
-            //{
-            //    VariableKind kind = VariableKind.LocalVariable;
-
-            //    if (_varKindMap.TryGetValue(varname, out kind))
-            //    {
-            //        return kind;
-            //    }
-            //}
-
-            // already declared on locals label
-            return Routine.LocalsTable.GetVariableKind(handle.Name);
-        }
-
         //#endregion
     }
 }

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundStatement.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundStatement.cs
@@ -216,15 +216,17 @@ namespace Pchp.CodeAnalysis.Semantics
     {
         public override OperationKind Kind => OperationKind.VariableDeclarationStatement;
 
-        ImmutableArray<IVariable> IVariableDeclarationStatement.Variables { get { throw new InvalidOperationException(); } }   // global variable does not have a symbol (yet?)
+        ImmutableArray<IVariable> IVariableDeclarationStatement.Variables => ImmutableArray.Create((IVariable)_variable);
 
-        public ImmutableArray<BoundVariable> Variables => _variables;
+        /// <summary>
+        /// The variable that will be referenced to a global variable.
+        /// </summary>
+        public BoundVariable Variable => _variable;
+        readonly BoundVariable _variable;
 
-        readonly ImmutableArray<BoundVariable> _variables;
-
-        public BoundGlobalVariableStatement(ImmutableArray<BoundVariable> variables)
+        public BoundGlobalVariableStatement(BoundVariable variable)
         {
-            _variables = variables;
+            _variable = variable;
         }
 
         public override void Accept(OperationVisitor visitor)
@@ -240,15 +242,27 @@ namespace Pchp.CodeAnalysis.Semantics
 
     public sealed partial class BoundStaticVariableStatement : BoundStatement, IVariableDeclarationStatement
     {
+        public struct StaticVarDecl
+        {
+            public BoundVariable Variable;
+            public BoundExpression InitialValue;
+
+            /// <summary>
+            /// Variable name.
+            /// </summary>
+            public string Name => Variable.Name;
+        }
+
         public override OperationKind Kind => OperationKind.VariableDeclarationStatement;
 
-        public ImmutableArray<IVariable> Variables => StaticCast<IVariable>.From(_variables);
+        ImmutableArray<IVariable> IVariableDeclarationStatement.Variables => ImmutableArray.Create((IVariable)_variable.Variable);
 
-        readonly ImmutableArray<BoundStaticLocal> _variables;
+        public StaticVarDecl Declaration => _variable;
+        readonly StaticVarDecl _variable;
 
-        public BoundStaticVariableStatement(ImmutableArray<BoundStaticLocal> variables)
+        public BoundStaticVariableStatement(StaticVarDecl variable)
         {
-            _variables = variables;
+            _variable = variable;
         }
 
         public override void Accept(OperationVisitor visitor)

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundVariable.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundVariable.cs
@@ -60,7 +60,7 @@ namespace Pchp.CodeAnalysis.Semantics
         private SourceLocalSymbol _symbol;
 
         internal BoundLocal(SourceLocalSymbol symbol)
-            : base(symbol.LocalKind)
+            : base(VariableKind.LocalVariable)
         {
             _symbol = symbol;
         }
@@ -114,27 +114,27 @@ namespace Pchp.CodeAnalysis.Semantics
 
     #endregion
 
-    #region BoundStaticLocal
+    //#region BoundStaticLocal
 
-    public partial class BoundStaticLocal : BoundLocal
-    {
-        protected BoundExpression _initialier;
+    //public partial class BoundStaticLocal : BoundLocal
+    //{
+    //    protected BoundExpression _initialier;
 
-        internal BoundStaticLocal(SourceLocalSymbol symbol, BoundExpression initializer)
-            : base(symbol)
-        {
-            _initialier = initializer;
-        }
+    //    internal BoundStaticLocal(SourceLocalSymbol symbol, BoundExpression initializer)
+    //        : base(symbol)
+    //    {
+    //        _initialier = initializer;
+    //    }
 
-        public override IExpression InitialValue => _initialier;
+    //    public override IExpression InitialValue => _initialier;
 
-        public void Update(BoundExpression initializer)
-        {
-            _initialier = initializer;
-        }
-    }
+    //    public void Update(BoundExpression initializer)
+    //    {
+    //        _initialier = initializer;
+    //    }
+    //}
 
-    #endregion
+    //#endregion
 
     #region BoundParameter
 
@@ -199,11 +199,11 @@ namespace Pchp.CodeAnalysis.Semantics
 
     #region BoundGlobalVariable
 
-    public partial class BoundGlobalVariable : BoundVariable
+    public partial class BoundSuperGlobalVariable : BoundVariable
     {
         private VariableName _name;
 
-        public BoundGlobalVariable(VariableName name)
+        public BoundSuperGlobalVariable(VariableName name)
             : base(VariableKind.GlobalVariable)
         {
             _name = name;

--- a/src/Peachpie.CodeAnalysis/Semantics/BoundVariable.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/BoundVariable.cs
@@ -114,28 +114,6 @@ namespace Pchp.CodeAnalysis.Semantics
 
     #endregion
 
-    //#region BoundStaticLocal
-
-    //public partial class BoundStaticLocal : BoundLocal
-    //{
-    //    protected BoundExpression _initialier;
-
-    //    internal BoundStaticLocal(SourceLocalSymbol symbol, BoundExpression initializer)
-    //        : base(symbol)
-    //    {
-    //        _initialier = initializer;
-    //    }
-
-    //    public override IExpression InitialValue => _initialier;
-
-    //    public void Update(BoundExpression initializer)
-    //    {
-    //        _initialier = initializer;
-    //    }
-    //}
-
-    //#endregion
-
     #region BoundParameter
 
     public partial class BoundParameter : BoundVariable, IParameterInitializer
@@ -197,7 +175,7 @@ namespace Pchp.CodeAnalysis.Semantics
 
     #endregion
 
-    #region BoundGlobalVariable
+    #region BoundSuperGlobalVariable
 
     public partial class BoundSuperGlobalVariable : BoundVariable
     {

--- a/src/Peachpie.CodeAnalysis/Semantics/Graph/BoundBlock.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/Graph/BoundBlock.cs
@@ -18,7 +18,7 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
     /// Represents control flow block.
     /// </summary>
     [DebuggerDisplay("{DebugDisplay}")]
-    public partial class BoundBlock : AstNode, IBlockStatement
+    public partial class BoundBlock : BoundStatement, IBlockStatement
     {
         /// <summary>
         /// Internal name of the block.
@@ -38,11 +38,6 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
         /// </summary>
         public int Tag { get { return _tag; } set { _tag = value; } }
         private int _tag;
-
-        /// <summary>
-        /// Associated syntax node.
-        /// </summary>
-        internal LangElement PhpSyntax { get; set; }
 
         /// <summary>
         /// Current naming context.
@@ -77,8 +72,15 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
         public bool IsDead => _ordinal < 0;
 
         internal BoundBlock()
+            :this(new List<BoundStatement>())
         {
-            _statements = new List<BoundStatement>();
+            
+        }
+
+        internal BoundBlock(List<BoundStatement> statements)
+        {
+            Debug.Assert(statements != null);
+            _statements = statements;
         }
 
         /// <summary>
@@ -134,16 +136,17 @@ namespace Pchp.CodeAnalysis.Semantics.Graph
         ImmutableArray<ILocalSymbol> IBlockStatement.Locals => Locals;
         protected virtual ImmutableArray<ILocalSymbol> Locals => ImmutableArray<ILocalSymbol>.Empty;
 
-        OperationKind IOperation.Kind => OperationKind.BlockStatement;
+        public override OperationKind Kind => OperationKind.BlockStatement;
 
         bool IOperation.IsInvalid => false;
 
         SyntaxNode IOperation.Syntax => null;
 
-        void IOperation.Accept(OperationVisitor visitor)
-            => visitor.VisitBlockStatement(this);
+        public override void Accept(PhpOperationVisitor visitor) => visitor.VisitBlockStatement(this);
 
-        TResult IOperation.Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
+        public override void Accept(OperationVisitor visitor) => visitor.VisitBlockStatement(this);
+
+        public override TResult Accept<TArgument, TResult>(OperationVisitor<TArgument, TResult> visitor, TArgument argument)
             => visitor.VisitBlockStatement(this, argument);
 
         #endregion

--- a/src/Peachpie.CodeAnalysis/Semantics/LocalsTable.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/LocalsTable.cs
@@ -107,19 +107,6 @@ namespace Pchp.CodeAnalysis.Semantics
         }
 
         /// <summary>
-        /// Gets kind of declared variable or <see cref="VariableKind.LocalVariable"/> by default.
-        /// </summary>
-        public VariableKind GetVariableKind(VariableName varname)
-        {
-            BoundVariable value;
-            return _dict.TryGetValue(varname, out value)
-                ? value.VariableKind
-                : varname.IsAutoGlobal
-                    ? VariableKind.GlobalVariable
-                    : VariableKind.LocalVariable;
-        }
-
-        /// <summary>
         /// Gets local variable or create local if not yet.
         /// </summary>
         public BoundVariable BindVariable(VariableName varname, TextSpan span)

--- a/src/Peachpie.CodeAnalysis/Semantics/PhpOperationVisitor.cs
+++ b/src/Peachpie.CodeAnalysis/Semantics/PhpOperationVisitor.cs
@@ -214,6 +214,11 @@ namespace Pchp.CodeAnalysis.Semantics
             
         }
 
+        public virtual void VisitBlockStatement(Graph.BoundBlock x)
+        {
+            x.Statements.ForEach(Accept);
+        }
+
         public virtual void VisitExpressionStatement(BoundExpressionStatement x)
         {
             Accept(x.Expression);

--- a/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLocalSymbol.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Source/SourceLocalSymbol.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Collections.Immutable;
 using System.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
 
 namespace Pchp.CodeAnalysis.Symbols
 {
@@ -44,26 +45,19 @@ namespace Pchp.CodeAnalysis.Symbols
     {
         readonly protected SourceRoutineSymbol _routine;
         readonly string _name;
-        readonly VariableKind _kind;
 
-        public SourceLocalSymbol(SourceRoutineSymbol routine, string name, VariableKind kind)
+        public SourceLocalSymbol(SourceRoutineSymbol routine, string name, TextSpan span)
         {
             Debug.Assert(routine != null);
             Debug.Assert(!string.IsNullOrWhiteSpace(name));
 
             _routine = routine;
             _name = name;
-            _kind = kind;
         }
 
         #region Symbol
 
         public override string Name => _name;
-
-        /// <summary>
-        /// Gets local kind.
-        /// </summary>
-        public VariableKind LocalKind => _kind;
 
         public override void Accept(SymbolVisitor visitor)
             => visitor.VisitLocal(this);
@@ -93,7 +87,7 @@ namespace Pchp.CodeAnalysis.Symbols
 
         public override bool IsSealed => true;
 
-        public override bool IsStatic => _kind == VariableKind.StaticVariable;
+        public override bool IsStatic => false;
 
         public override bool IsVirtual => false;
 
@@ -146,7 +140,7 @@ namespace Pchp.CodeAnalysis.Symbols
         readonly TypeSymbol _type;
 
         public SynthesizedLocalSymbol(SourceRoutineSymbol routine, string name, TypeSymbol type)
-            :base(routine, name + "#", VariableKind.LocalVariable)
+            : base(routine, name + "'", default(TextSpan))
         {
             Contract.ThrowIfNull(type);
             _type = type;

--- a/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedStaticLocHolder.cs
+++ b/src/Peachpie.CodeAnalysis/Symbols/Synthesized/SynthesizedStaticLocHolder.cs
@@ -24,16 +24,19 @@ namespace Pchp.CodeAnalysis.Symbols
         /// <summary>
         /// Containing source routine.
         /// </summary>
+        public IMethodSymbol DeclaringMethod => _routine;
         readonly SourceRoutineSymbol _routine;
 
         /// <summary>
         /// Name of the local variable.
         /// </summary>
+        public string VariableName => _locName;
         readonly string _locName;
 
         /// <summary>
         /// Type of local variable.
         /// </summary>
+        public TypeSymbol ValueType => _locType;
         readonly TypeSymbol _locType;
 
         public override bool IsImplicitlyDeclared => true;

--- a/src/Tests/Peachpie.DiagnosticTests/tests/type_analysis_01.php
+++ b/src/Tests/Peachpie.DiagnosticTests/tests/type_analysis_01.php
@@ -70,4 +70,5 @@ function baz(int /*|integer|*/$x) {
 }
 
 /*|integer|*/$i = 5;
-echo /*|integer|*/$i;
+// global variables may be changed from outside, so the type is always mixed
+echo /*|mixed|*/$i;

--- a/tests/generators/generators_012_staticlocal.php
+++ b/tests/generators/generators_012_staticlocal.php
@@ -19,4 +19,4 @@ foreach($gen as $key => $value){
     echo "k:".$key."v:".$value."\n";
 }
 
-
+echo "Done.";


### PR DESCRIPTION
- changed the way of handling declaration of static and global variables
- that variable is maintained as local and the `static` and `global` keywords assign a reference to it
- type analysis changed accordingly
- compiler handles declaration as following:
  - `static $a` : $a = Context.GetStatic<$a>().Value;
  - `global $a` : $a = &$GLOBALS['a']

This approach removes limitations of special handling for static and global variables, allows mixing with local and parameters, allows static and globals in generators, simplifies the code, has a small impact on performance but not measurable.